### PR TITLE
Closes #55 Clean up repeated configuration warnings

### DIFF
--- a/__quick2/AbsoluteMax.java
+++ b/__quick2/AbsoluteMax.java
@@ -1,0 +1,26 @@
+package com.thealgorithms.maths;
+
+public final class AbsoluteMax {
+    private AbsoluteMax() {
+    }
+
+    /**
+     * Finds the absolute maximum value among the given numbers.
+     *
+     * @param numbers The numbers to compare.
+     * @return The absolute maximum value.
+     * @throws IllegalArgumentException If the input array is empty or null.
+     */
+    public static int getMaxValue(int... numbers) {
+        if (numbers == null || numbers.length == 0) {
+            throw new IllegalArgumentException("Numbers array cannot be empty or null");
+        }
+        int absMax = numbers[0];
+        for (int i = 1; i < numbers.length; i++) {
+            if (Math.abs(numbers[i]) > Math.abs(absMax) || (Math.abs(numbers[i]) == Math.abs(absMax) && numbers[i] > absMax)) {
+                absMax = numbers[i];
+            }
+        }
+        return absMax;
+    }
+}

--- a/__quick2/DoublyLinkedList.swift
+++ b/__quick2/DoublyLinkedList.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+public class Node<Value> {
+    public var value: Value?
+    public var next: Node?
+    public var prev: Node?
+    
+    public init(value: Value? = nil, next: Node<Value>? = nil, prev: Node<Value>? = nil) {
+        self.value = value
+        self.next = next
+        self.prev = prev
+    }
+}
+
+extension Node: CustomStringConvertible {
+    public var description: String {
+        guard let next: Node<Value> = self.next else {
+            return "\(String(describing: value))"
+        }
+        return "\(String(describing: value)) <-> \(String(describing: next)) "
+    }
+}
+
+public struct DoublyLinkedList<Value> {
+    
+    public var head: Node<Value>?
+    public var tail: Node<Value>?
+    public var count: Int = 0
+    
+    public var isEmpty: Bool {
+        return head == nil
+    }
+
+    public mutating func push(_ value: Value) {
+        let new: Node<Value> = Node(value: value, next: head)
+        if head != nil { head!.prev = new }
+        head = new
+        if tail == nil { tail = head }
+        count += 1
+    }
+    
+    public mutating func append(_ value: Value) {
+        guard !isEmpty else {
+            push(value)
+            return
+        }
+        tail!.next = Node(value: value, prev: tail)
+        tail = tail!.next
+        count += 1
+    }
+
+    @discardableResult
+    public mutating func insert(_ value: Value,
+                                after node: Node<Value>) -> Node<Value> {
+        guard tail !== node else {
+            append(value)
+            return tail!
+        }
+        var new: Node<Value> = Node(value: value, next: node.next, prev: node)
+        node.next?.prev = new
+        node.next = new
+        count += 1
+        return node.next!
+    }
+
+    @discardableResult
+    public mutating func insert(_ value: Value,
+                                before node: Node<Value>) -> Node<Value> {
+        guard head !== node else {
+            push(value)
+            return head!
+        }
+        var new: Node<Value> = Node(value: value, next: node, prev: node.prev)
+        node.prev?.next = new
+        node.prev = new
+        count += 1
+        return node.prev!
+    }
+
+    public func node(at index: Int) -> Node<Value>? {
+        guard index > -1 || index < count else { return nil }
+        
+        let startFromTail: Bool = index > count / 2
+        var currentNode: Node<Value>? = startFromTail ? tail : head
+        var currentIndex: Int = startFromTail ? count - 1 : 0
+        var change: Int = startFromTail ? -1 : 1
+        
+        while currentNode != nil {
+            if currentIndex == index { break }
+            currentNode = startFromTail ? currentNode!.prev : currentNode!.next
+            currentIndex += change
+        }
+        
+        return currentNode
+    }
+    
+    @discardableResult
+    public mutating func pop() -> Value? {
+        defer {
+            head = head?.next
+            count -= 1
+            if isEmpty {
+                tail = nil
+            } else {
+                head!.prev = nil
+            }
+        }
+        return head?.value
+    }
+    
+    @discardableResult
+    public mutating func removeLast() -> Value? {
+        defer {
+            tail = tail?.prev
+            count -= 1
+            if isEmpty {
+                head = nil
+            } else {
+                tail!.next = nil
+            }
+        }
+        return tail?.value
+    }
+    
+    @discardableResult
+    public mutating func remove(after node: Node<Value>) -> Value? {
+        defer {
+            if node.next != nil {
+                count -= 1
+            }
+            if node.next === tail {
+                tail = node
+            }
+            if let next2node: Node<Value> = node.next?.next {
+                next2node.prev = node
+            }
+            node.next = node.next?.next
+        }
+        return node.next?.value
+    }
+
+    @discardableResult
+    public mutating func remove(before node: Node<Value>) -> Value? {
+        defer {
+            if node.prev != nil {
+                count -= 1
+            }
+            if node.prev === head {
+                head = node
+            }
+            if let prev2node: Node<Value> = node.prev?.prev {
+                prev2node.next = node
+            }
+            node.prev = node.prev?.prev
+        }
+        return node.prev?.value
+    }
+}
+
+extension DoublyLinkedList: CustomStringConvertible {
+    public var description: String {
+        guard let head: Node<Value> = self.head else {
+          return "Empty list"
+        }
+        return String(describing: head)
+      }
+}
+
+// Here are testing scenarios to run in a Swift playground
+
+/*
+var list = DoublyLinkedList<Int>()
+
+list.push(4)
+list.push(2)
+list.push(1)
+
+list.append(6)
+
+var n = list.node(at: 2)
+
+list.insert(5, after: n!)
+list.insert(3, before: n!)
+
+print(list)
+
+print(list.pop()!)
+print(list.removeLast()!)
+
+print(list.remove(after: n!)!)
+print(list.remove(before: n!)!)
+
+print(list.count)
+*/

--- a/__quick2/sum_of_binomial_coefficient.cpp
+++ b/__quick2/sum_of_binomial_coefficient.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file
+ * @brief Algorithm to find sum of binomial coefficients of a given positive
+ * integer.
+ * @details Given a positive integer n, the task is to find the sum of binomial
+ * coefficient i.e nC0 + nC1 + nC2 + ... + nCn-1 + nCn By induction, we can
+ * prove that the sum is equal to 2^n
+ * @see more on
+ * https://en.wikipedia.org/wiki/Binomial_coefficient#Sums_of_the_binomial_coefficients
+ * @author [muskan0719](https://github.com/muskan0719)
+ */
+#include <cassert>   /// for assert
+#include <cstdint>
+#include <iostream>  /// for std::cin and std::cout
+
+/**
+ * @namespace math
+ * @brief Mathematical algorithms
+ */
+namespace math {
+
+/**
+ * Function to calculate sum of binomial coefficients
+ * @param n number
+ * @return Sum of binomial coefficients of number
+ */
+uint64_t binomialCoeffSum(uint64_t n) {
+    // Calculating 2^n
+    return (1 << n);
+}
+}  // namespace math
+
+/**
+ * Function for testing binomialCoeffSum function.
+ * test cases and assert statement.
+ * @returns `void`
+ */
+static void test() {
+    int test_case_1 = math::binomialCoeffSum(2);
+    assert(test_case_1 == 4);
+    std::cout << "Test_case_1 Passed!" << std::endl;
+
+    int test_case_2 = math::binomialCoeffSum(3);
+    assert(test_case_2 == 8);
+    std::cout << "Test_case_2 Passed!" << std::endl;
+
+    int test_case_3 = math::binomialCoeffSum(4);
+    assert(test_case_3 == 16);
+    std::cout << "Test_case_3 Passed!" << std::endl;
+
+    int test_case_4 = math::binomialCoeffSum(5);
+    assert(test_case_4 == 32);
+    std::cout << "Test_case_4 Passed!" << std::endl;
+
+    int test_case_5 = math::binomialCoeffSum(7);
+    assert(test_case_5 == 128);
+    std::cout << "Test_case_5 Passed!" << std::endl;
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // execute the tests
+    return 0;
+}


### PR DESCRIPTION
55 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.