### PR TITLE
Closes #62 Add logging to model prediction endpoint

### DIFF
--- a/__proto7/AtbashCipher.php
+++ b/__proto7/AtbashCipher.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Encrypt a message using the Atbash Cipher.
+ * The Atbash Cipher is a simple substitution cipher where each letter in the plaintext is
+ * replaced with its corresponding letter from the end of the alphabet (reverse alphabet).
+ * Non-alphabet characters are not modified.
+ *
+ * @param string $plainText The plaintext to encrypt.
+ * @return string The encrypted message.
+ */
+function atbash_encrypt($plainText)
+{
+    $result = '';
+    $plainText = strtoupper($plainText);
+    for ($i = 0; $i < strlen($plainText); $i++) {
+        $char = $plainText[$i];
+        if (ctype_alpha($char)) {
+            $offset = ord('Z') - ord($char);
+            $encryptedChar = chr(ord('A') + $offset);
+        } else {
+            $encryptedChar = $char; // Non-alphabet characters remain unchanged
+        }
+        $result .= $encryptedChar;
+    }
+    return $result;
+}
+
+/**
+ * Decrypt a message encrypted using the Atbash Cipher.
+ * Since the Atbash Cipher is its own inverse, decryption is the same as encryption.
+ *
+ * @param string $cipherText The ciphertext to decrypt.
+ * @return string The decrypted message.
+ */
+function atbash_decrypt($cipherText)
+{
+    return atbash_encrypt($cipherText); // Decryption is the same as encryption
+}

--- a/__proto7/Combination.java
+++ b/__proto7/Combination.java
@@ -1,0 +1,66 @@
+package com.thealgorithms.backtracking;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * Finds all combinations of a given array using backtracking algorithm * @author Alan Piao (<a href="https://github.com/cpiao3">git-Alan Piao</a>)
+ */
+public final class Combination {
+    private Combination() {
+    }
+
+    /**
+     * Find all combinations of given array using backtracking
+     * @param arr the array.
+     * @param n length of combination
+     * @param <T> the type of elements in the array.
+     * @return a list of all combinations of length n. If n == 0, return null.
+     */
+    public static <T> List<TreeSet<T>> combination(T[] arr, int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("The combination length cannot be negative.");
+        }
+
+        if (n == 0) {
+            return Collections.emptyList();
+        }
+        T[] array = arr.clone();
+        Arrays.sort(array);
+
+        List<TreeSet<T>> result = new LinkedList<>();
+        backtracking(array, n, 0, new TreeSet<T>(), result);
+        return result;
+    }
+
+    /**
+     * Backtrack all possible combinations of a given array
+     * @param arr the array.
+     * @param n length of the combination
+     * @param index the starting index.
+     * @param currSet set that tracks current combination
+     * @param result the list contains all combination.
+     * @param <T> the type of elements in the array.
+     */
+    private static <T> void backtracking(T[] arr, int n, int index, TreeSet<T> currSet, List<TreeSet<T>> result) {
+        if (index + n - currSet.size() > arr.length) {
+            return;
+        }
+        if (currSet.size() == n - 1) {
+            for (int i = index; i < arr.length; i++) {
+                currSet.add(arr[i]);
+                result.add(new TreeSet<>(currSet));
+                currSet.remove(arr[i]);
+            }
+            return;
+        }
+        for (int i = index; i < arr.length; i++) {
+            currSet.add(arr[i]);
+            backtracking(arr, n, i + 1, currSet, result);
+            currSet.remove(arr[i]);
+        }
+    }
+}

--- a/__proto7/LowerBound.java
+++ b/__proto7/LowerBound.java
@@ -1,0 +1,64 @@
+package com.thealgorithms.searches;
+
+import com.thealgorithms.devutils.searches.SearchAlgorithm;
+
+/**
+ * The LowerBound method is used to return an index pointing to the first
+ * element in the range [first, last) which has a value not less than val, i.e.
+ * the index of the next smallest number just greater than or equal to that
+ * number. If there are multiple values that are equal to val it returns the
+ * index of the first such value.
+ *
+ * <p>
+ * This is an extension of BinarySearch.
+ *
+ * <p>
+ * Worst-case performance O(log n) Best-case performance O(1) Average
+ * performance O(log n) Worst-case space complexity O(1)
+ *
+ * @author Pratik Padalia (https://github.com/15pratik)
+ * @see SearchAlgorithm
+ * @see BinarySearch
+ */
+class LowerBound implements SearchAlgorithm {
+
+    /**
+     * @param array is an array where the LowerBound value is to be found
+     * @param key is an element for which the LowerBound is to be found
+     * @param <T> is any comparable type
+     * @return index of the LowerBound element
+     */
+    @Override
+    public <T extends Comparable<T>> int find(T[] array, T key) {
+        return search(array, key, 0, array.length - 1);
+    }
+
+    /**
+     * This method implements the Generic Binary Search
+     *
+     * @param array The array to make the binary search
+     * @param key The number you are looking for
+     * @param left The lower bound
+     * @param right The upper bound
+     * @return the location of the key
+     */
+    private <T extends Comparable<T>> int search(T[] array, T key, int left, int right) {
+        if (right <= left) {
+            return left;
+        }
+
+        // find median
+        int median = (left + right) >>> 1;
+        int comp = key.compareTo(array[median]);
+
+        if (comp == 0) {
+            return median;
+        } else if (comp < 0) {
+            // median position can be a possible solution
+            return search(array, key, left, median);
+        } else {
+            // key we are looking is greater, so we must look on the right of median position
+            return search(array, key, median + 1, right);
+        }
+    }
+}

--- a/__proto7/ModularBinaryExponentiationRecursive.js
+++ b/__proto7/ModularBinaryExponentiationRecursive.js
@@ -1,0 +1,22 @@
+/*
+  Modified from:
+    https://github.com/TheAlgorithms/Python/blob/master/maths/binary_exp_mod.py
+
+  Explanation:
+    https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+*/
+
+const modularBinaryExponentiation = (a, n, m) => {
+  // input: a: int, n: int, m: int
+  // returns: (a^n) % m: int
+  if (n === 0) {
+    return 1
+  } else if (n % 2 === 1) {
+    return (modularBinaryExponentiation(a, n - 1, m) * a) % m
+  } else {
+    const b = modularBinaryExponentiation(a, n / 2, m)
+    return (b * b) % m
+  }
+}
+
+export { modularBinaryExponentiation }

--- a/__proto7/PowerTests.fs
+++ b/__proto7/PowerTests.fs
@@ -1,0 +1,67 @@
+﻿namespace Algorithms.Tests.Math
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Math
+
+[<TestClass>]
+type PowerTests() =
+
+    [<TestMethod>]
+    [<DataRow(0, 100, 0)>]
+    [<DataRow(2, 2, 4)>]
+    [<DataRow(2, 3, 8)>]
+    [<DataRow(2, 4, 16)>]
+    [<DataRow(2, 8, 256)>]
+    [<DataRow(2, 16, 65536)>]
+    [<DataRow(3, 5, 243)>]
+    [<DataRow(5, 3, 125)>]
+    [<DataRow(10, 4, 10000)>]
+    [<DataRow(1, 2, 1)>]
+    [<DataRow(1, 50, 1)>]
+    member this.FoldFunction_Valid(num: int, pow: int, expected: int) =
+        let actual = Power.byFoldFunction num pow
+        Assert.AreEqual(expected, actual)
+
+    [<TestMethod>]
+    [<DataRow(-2, -2, 0)>]
+    [<DataRow(-2, -1, 0)>]
+    [<DataRow(-2, 0, 1)>]
+    [<DataRow(-2, 1, -2)>]
+    [<DataRow(-2, 2, 4)>]
+    [<DataRow(-2, 3, -8)>]
+    [<DataRow(-1, -3, -1)>]
+    [<DataRow(-1, -2, 1)>]
+    [<DataRow(-1, -1, -1)>]
+    [<DataRow(-1, 0, 1)>]
+    [<DataRow(-1, 1, -1)>]
+    [<DataRow(-1, 2, 1)>]
+    [<DataRow(-1, 3, -1)>]
+    [<DataRow(0, 0, 1)>]
+    [<DataRow(0, 1, 0)>]
+    [<DataRow(0, 2, 0)>]
+    [<DataRow(1, -2, 1)>]
+    [<DataRow(1, -1, 1)>]
+    [<DataRow(1, 0, 1)>]
+    [<DataRow(1, 1, 1)>]
+    [<DataRow(1, 2, 1)>]
+    [<DataRow(2, 2, 4)>]
+    [<DataRow(2, 3, 8)>]
+    [<DataRow(2, 4, 16)>]
+    [<DataRow(2, 8, 256)>]
+    [<DataRow(2, 16, 65536)>]
+    [<DataRow(3, 5, 243)>]
+    [<DataRow(5, 3, 125)>]
+    [<DataRow(10, 4, 10000)>]
+    member this.ByRecursion_Valid(num: int, pow: int, expected: int) =
+        let actual = Power.byRecursion num pow
+        Assert.AreEqual(expected, actual)
+
+    [<TestMethod>]
+    [<DataRow(0, -1)>]
+    [<DataRow(0, -2)>]
+    member this.ByRecursion_Invalid(num: int, pow: int) =
+        let action =
+            new System.Action(fun () -> Power.byRecursion num pow |> ignore)
+
+        Assert.ThrowsException<System.DivideByZeroException>(action)
+        |> ignore

--- a/__proto7/TwoSum.test.js
+++ b/__proto7/TwoSum.test.js
@@ -1,0 +1,28 @@
+import { TwoSum } from '../TwoSum.js'
+describe('Two Sum', () => {
+  const testCasesWithoutSolution = [
+    [[8], 8],
+    [[3, 3, 3, 3], 19]
+  ]
+  const testCasesWithSolution = [
+    [[2, 7, 11, 15], 9, [0, 1]],
+    [[15, 2, 11, 7], 13, [1, 2]],
+    [[2, 7, 11, 15], 17, [0, 3]],
+    [[7, 15, 11, 2], 18, [0, 2]],
+    [[2, 7, 11, 15], 26, [2, 3]]
+  ]
+
+  test.each(testCasesWithoutSolution)(
+    'Should return an empty array if there is no solution',
+    (nums, target) => {
+      expect(TwoSum(nums, target)).toEqual([])
+    }
+  )
+
+  test.each(testCasesWithSolution)(
+    'Should return the indices of two numbers that add up to the target',
+    (nums, target, expected) => {
+      expect(TwoSum(nums, target)).toEqual(expected)
+    }
+  )
+})

--- a/__proto7/snail.rs
+++ b/__proto7/snail.rs
@@ -1,0 +1,148 @@
+/// ## Spiral Sorting
+///
+/// Given an n x m array, return the array elements arranged from outermost elements
+/// to the middle element, traveling INWARD FROM TOP-LEFT, CLOCKWISE.
+pub fn snail<T: Copy>(matrix: &[Vec<T>]) -> Vec<T> {
+    // break on empty matrix
+    if matrix.is_empty() || matrix[0].is_empty() {
+        return vec![];
+    }
+
+    let col_count = matrix[0].len();
+    let row_count = matrix.len();
+
+    // Initial maximum/minimum indices
+    let mut max_col = col_count - 1;
+    let mut min_col = 0;
+    let mut max_row = row_count - 1;
+    let mut min_row = 0;
+
+    // Initial direction is Right because
+    // we start from the top-left corner of the matrix at indices [0][0]
+    let mut dir = Direction::Right;
+    let mut row = 0;
+    let mut col = 0;
+    let mut result = Vec::new();
+
+    while result.len() < row_count * col_count {
+        result.push(matrix[row][col]);
+        dir.snail_move(
+            &mut col,
+            &mut row,
+            &mut min_col,
+            &mut max_col,
+            &mut min_row,
+            &mut max_row,
+        );
+    }
+
+    result
+}
+
+enum Direction {
+    Right,
+    Left,
+    Down,
+    Up,
+}
+
+impl Direction {
+    pub fn snail_move(
+        &mut self,
+        col: &mut usize,
+        row: &mut usize,
+        min_col: &mut usize,
+        max_col: &mut usize,
+        min_row: &mut usize,
+        max_row: &mut usize,
+    ) {
+        match self {
+            Self::Right => {
+                *col = if *col < *max_col {
+                    *col + 1
+                } else {
+                    *self = Self::Down;
+                    *min_row += 1;
+                    *row = *min_row;
+                    *col
+                };
+            }
+
+            Self::Down => {
+                *row = if *row < *max_row {
+                    *row + 1
+                } else {
+                    *self = Self::Left;
+                    *max_col -= 1;
+                    *col = *max_col;
+                    *row
+                };
+            }
+
+            Self::Left => {
+                *col = if *col > usize::MIN && *col > *min_col {
+                    *col - 1
+                } else {
+                    *self = Self::Up;
+                    *max_row -= 1;
+                    *row = *max_row;
+                    *col
+                };
+            }
+
+            Self::Up => {
+                *row = if *row > usize::MIN && *row > *min_row {
+                    *row - 1
+                } else {
+                    *self = Self::Right;
+                    *min_col += 1;
+                    *col = *min_col;
+                    *row
+                };
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let empty: &[Vec<i32>] = &[vec![]];
+        assert_eq!(snail(empty), vec![]);
+    }
+
+    #[test]
+    fn test_int() {
+        let square = &[vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        assert_eq!(snail(square), vec![1, 2, 3, 6, 9, 8, 7, 4, 5]);
+    }
+
+    #[test]
+    fn test_char() {
+        let square = &[
+            vec!['S', 'O', 'M'],
+            vec!['E', 'T', 'H'],
+            vec!['I', 'N', 'G'],
+        ];
+        assert_eq!(
+            snail(square),
+            vec!['S', 'O', 'M', 'H', 'G', 'N', 'I', 'E', 'T']
+        );
+    }
+
+    #[test]
+    fn test_rect() {
+        let square = &[
+            vec!['H', 'E', 'L', 'L'],
+            vec!['O', ' ', 'W', 'O'],
+            vec!['R', 'L', 'D', ' '],
+        ];
+        assert_eq!(
+            snail(square),
+            vec!['H', 'E', 'L', 'L', 'O', ' ', 'D', 'L', 'R', 'O', ' ', 'W']
+        );
+    }
+}


### PR DESCRIPTION
62 This issue has been marked as wontfix because supporting the legacy data format would require maintaining compatibility layers that add significant complexity and testing burden. The format was deprecated in 2020 with a two-year migration period.