### PR TITLE
Closes #66 Refactor: Reconcile duplicate ARM64 build strategies for base-calling

### DIFF
--- a/__temp3/gaussin_legendre.f90
+++ b/__temp3/gaussin_legendre.f90
@@ -1,0 +1,172 @@
+!> Test program for the Gaussian Legendre Quadrature module
+!!
+!!  Created by: Your Name (https://github.com/YourGitHub)
+!!  in Pull Request: #32
+!!  https://github.com/TheAlgorithms/Fortran/pull/32
+!!
+!!  This program provides test cases to validate the gaussian_legendre_quadrature module against known integral values.
+
+program test_gaussian_legendre_quadrature
+    use gaussian_legendre_quadrature
+    implicit none
+
+    ! Run test cases
+    call test_integral_x_squared_0_to_1()
+    call test_integral_e_x_0_to_1()
+    call test_integral_sin_0_to_pi()
+    call test_integral_cos_0_to_pi_over_2()
+    call test_integral_1_over_x_1_to_e()
+    call test_integral_x_cubed_0_to_1()
+    call test_integral_sin_squared_0_to_pi()
+    call test_integral_1_over_x_1_to_e()
+
+    print *, "All tests completed."
+
+contains
+
+    ! Test case 1: ∫ x^2 dx from 0 to 1 (Exact result = 1/3 ≈ 0.3333)
+    subroutine test_integral_x_squared_0_to_1()
+        real(dp) :: lower_bound, upper_bound, integral_result, expected
+        integer :: panels_number
+        lower_bound = 0.0_dp
+        upper_bound = 1.0_dp
+        panels_number = 5           ! Adjust the number of quadrature points as needed from 1 to 5
+        expected = 1.0_dp/3.0_dp
+        call gauss_legendre_quadrature(integral_result, lower_bound, upper_bound, panels_number, f_x_squared)
+        call assert_test(integral_result, expected, "Test 1: ∫ x^2 dx from 0 to 1")
+    end subroutine test_integral_x_squared_0_to_1
+
+    ! Test case 2: ∫ e^x dx from 0 to 1 (Exact result = e - 1 ≈ 1.7183)
+    subroutine test_integral_e_x_0_to_1()
+        real(dp) :: lower_bound, upper_bound, integral_result, expected
+        integer :: panels_number
+        lower_bound = 0.0_dp
+        upper_bound = 1.0_dp
+        panels_number = 3
+        expected = exp(1.0_dp) - 1.0_dp
+        call gauss_legendre_quadrature(integral_result, lower_bound, upper_bound, panels_number, exp_function)
+        call assert_test(integral_result, expected, "Test 2: ∫ e^x dx from 0 to 1")
+    end subroutine test_integral_e_x_0_to_1
+
+    ! Test case 3: ∫ sin(x) dx from 0 to π (Exact result = 2)
+    subroutine test_integral_sin_0_to_pi()
+        real(dp) :: lower_bound, upper_bound, integral_result, expected
+        integer :: panels_number
+        real(dp), parameter :: pi = 4.D0*DATAN(1.D0)  ! Define Pi. Ensure maximum precision available on any architecture.
+        lower_bound = 0.0_dp
+        upper_bound = pi
+        panels_number = 5
+        expected = 2.0_dp
+        call gauss_legendre_quadrature(integral_result, lower_bound, upper_bound, panels_number, sin_function)
+        call assert_test(integral_result, expected, "Test 3: ∫ sin(x) dx from 0 to π")
+    end subroutine test_integral_sin_0_to_pi
+
+    ! Test case 4: ∫ cos(x) dx from 0 to π/2 (Exact result = 1)
+    subroutine test_integral_cos_0_to_pi_over_2()
+        real(dp) :: lower_bound, upper_bound, integral_result, expected
+        real(dp), parameter :: pi = 4.D0*DATAN(1.D0)  ! Define Pi. Ensure maximum precision available on any architecture.
+        integer :: panels_number
+        lower_bound = 0.0_dp
+        upper_bound = pi/2.0_dp
+        panels_number = 5
+        expected = 1.0_dp
+        call gauss_legendre_quadrature(integral_result, lower_bound, upper_bound, panels_number, cos_function)
+        call assert_test(integral_result, expected, "Test 4: ∫ cos(x) dx from 0 to π/2")
+    end subroutine test_integral_cos_0_to_pi_over_2
+
+    ! Test case 5: ∫ (1/x) dx from 1 to e (Exact result = 1)
+    subroutine test_integral_1_over_x_1_to_e()
+        real(dp) :: lower_bound, upper_bound, integral_result, expected
+        integer :: panels_number
+        lower_bound = 1.0_dp
+        upper_bound = exp(1.0_dp)
+        panels_number = 5
+        expected = 1.0_dp
+        call gauss_legendre_quadrature(integral_result, lower_bound, upper_bound, panels_number, log_function)
+        call assert_test(integral_result, expected, "Test 5: ∫ (1/x) dx from 1 to e")
+    end subroutine test_integral_1_over_x_1_to_e
+
+    ! Test case 6: ∫ x^3 dx from 0 to 1 (Exact result = 1/4 = 0.25)
+    subroutine test_integral_x_cubed_0_to_1()
+        real(dp) :: lower_bound, upper_bound, integral_result, expected
+        integer :: panels_number
+        lower_bound = 0.0_dp
+        upper_bound = 1.0_dp
+        panels_number = 4
+        expected = 0.25_dp
+        call gauss_legendre_quadrature(integral_result, lower_bound, upper_bound, panels_number, f_x_cubed)
+        call assert_test(integral_result, expected, "Test 6: ∫ x^3 dx from 0 to 1")
+    end subroutine test_integral_x_cubed_0_to_1
+
+    ! Test case 7: ∫ sin^2(x) dx from 0 to π (Exact result = π/2 ≈ 1.5708)
+    subroutine test_integral_sin_squared_0_to_pi()
+        real(dp) :: lower_bound, upper_bound, integral_result, expected
+        real(dp), parameter :: pi = 4.D0*DATAN(1.D0)  ! Define Pi. Ensure maximum precision available on any architecture.
+        integer :: panels_number
+        lower_bound = 0.0_dp
+        upper_bound = pi
+        panels_number = 5
+        expected = 1.57084_dp    ! Approximate value, adjust tolerance as needed
+        call gauss_legendre_quadrature(integral_result, lower_bound, upper_bound, panels_number, sin_squared_function)
+        call assert_test(integral_result, expected, "Test 7: ∫ sin^2(x) dx from 0 to π")
+    end subroutine test_integral_sin_squared_0_to_pi
+
+    ! Function for x^2
+    real(dp) function f_x_squared(x)
+        real(dp), intent(in) :: x
+        f_x_squared = x**2
+    end function f_x_squared
+
+    ! Function for e^x
+    real(dp) function exp_function(x)
+        real(dp), intent(in) :: x
+        exp_function = exp(x)
+    end function exp_function
+
+    ! Function for 1/x
+    real(dp) function log_function(x)
+        real(dp), intent(in) :: x
+        log_function = 1.0_dp/x
+    end function log_function
+
+    ! Function for cos(x)
+    real(dp) function cos_function(x)
+        real(dp), intent(in) :: x
+        cos_function = cos(x)
+    end function cos_function
+
+    ! Function for x^3
+    real(dp) function f_x_cubed(x)
+        real(dp), intent(in) :: x
+        f_x_cubed = x**3
+    end function f_x_cubed
+
+    ! Function for sin(x)
+    real(dp) function sin_function(x)
+        real(dp), intent(in) :: x
+        sin_function = sin(x)
+    end function sin_function
+
+    ! Function for sin^2(x)
+    real(dp) function sin_squared_function(x)
+        real(dp), intent(in) :: x
+        sin_squared_function = sin(x)**2
+    end function sin_squared_function
+
+    !> Subroutine to assert the test results
+    subroutine assert_test(actual, expected, test_name)
+        real(dp), intent(in) :: actual, expected
+        character(len=*), intent(in) :: test_name
+        real(dp), parameter :: tol = 1.0e-5_dp
+
+        if (abs(actual - expected) < tol) then
+            print *, test_name, " PASSED"
+        else
+            print *, test_name, " FAILED"
+            print *, " Expected: ", expected
+            print *, " Got:      ", actual
+            stop 1
+        end if
+    end subroutine assert_test
+
+end program test_gaussian_legendre_quadrature

--- a/__temp3/graham_scan.rs
+++ b/__temp3/graham_scan.rs
@@ -1,0 +1,206 @@
+use crate::geometry::Point;
+use std::cmp::Ordering;
+
+fn point_min(a: &&Point, b: &&Point) -> Ordering {
+    // Find the bottom-most point. In the case of a tie, find the left-most.
+    if a.y == b.y {
+        a.x.partial_cmp(&b.x).unwrap()
+    } else {
+        a.y.partial_cmp(&b.y).unwrap()
+    }
+}
+
+// Returns a Vec of Points that make up the convex hull of `points`. Returns an empty Vec if there
+// is no convex hull.
+pub fn graham_scan(mut points: Vec<Point>) -> Vec<Point> {
+    if points.len() <= 2 {
+        return vec![];
+    }
+
+    let min_point = points.iter().min_by(point_min).unwrap().clone();
+    points.retain(|p| p != &min_point);
+    if points.is_empty() {
+        // edge case where all the points are the same
+        return vec![];
+    }
+
+    let point_cmp = |a: &Point, b: &Point| -> Ordering {
+        // Sort points in counter-clockwise direction relative to the min point. We can this by
+        // checking the orientation of consecutive vectors (min_point, a) and (a, b).
+        let orientation = min_point.consecutive_orientation(a, b);
+        if orientation < 0.0 {
+            Ordering::Greater
+        } else if orientation > 0.0 {
+            Ordering::Less
+        } else {
+            let a_dist = min_point.euclidean_distance(a);
+            let b_dist = min_point.euclidean_distance(b);
+            // When two points have the same relative angle to the min point, we should only
+            // include the further point in the convex hull. We sort further points into a lower
+            // index, and in the algorithm, remove all consecutive points with the same relative
+            // angle.
+            b_dist.partial_cmp(&a_dist).unwrap()
+        }
+    };
+    points.sort_by(point_cmp);
+    let mut convex_hull: Vec<Point> = vec![];
+
+    // We always add the min_point, and the first two points in the sorted vec.
+    convex_hull.push(min_point.clone());
+    convex_hull.push(points[0].clone());
+    let mut top = 1;
+    for point in points.iter().skip(1) {
+        if min_point.consecutive_orientation(point, &convex_hull[top]) == 0.0 {
+            // Remove consecutive points with the same angle. We make sure include the furthest
+            // point in the convex hull in the sort comparator.
+            continue;
+        }
+        loop {
+            // In this loop, we remove points that we determine are no longer part of the convex
+            // hull.
+            if top <= 1 {
+                break;
+            }
+            // If there is a segment(i+1, i+2) turns right relative to segment(i, i+1), point(i+1)
+            // is not part of the convex hull.
+            let orientation =
+                convex_hull[top - 1].consecutive_orientation(&convex_hull[top], point);
+            if orientation <= 0.0 {
+                top -= 1;
+                convex_hull.pop();
+            } else {
+                break;
+            }
+        }
+        convex_hull.push(point.clone());
+        top += 1;
+    }
+    if convex_hull.len() <= 2 {
+        return vec![];
+    }
+    convex_hull
+}
+
+#[cfg(test)]
+mod tests {
+    use super::graham_scan;
+    use super::Point;
+
+    fn test_graham(convex_hull: Vec<Point>, others: Vec<Point>) {
+        let mut points = convex_hull.clone();
+        points.append(&mut others.clone());
+        let graham = graham_scan(points);
+        for point in convex_hull {
+            assert!(graham.contains(&point));
+        }
+        for point in others {
+            assert!(!graham.contains(&point));
+        }
+    }
+
+    #[test]
+    fn too_few_points() {
+        test_graham(vec![], vec![]);
+        test_graham(vec![], vec![Point::new(0.0, 0.0)]);
+    }
+
+    #[test]
+    fn duplicate_point() {
+        let p = Point::new(0.0, 0.0);
+        test_graham(vec![], vec![p.clone(), p.clone(), p.clone(), p.clone(), p]);
+    }
+
+    #[test]
+    fn points_same_line() {
+        let p1 = Point::new(1.0, 0.0);
+        let p2 = Point::new(2.0, 0.0);
+        let p3 = Point::new(3.0, 0.0);
+        let p4 = Point::new(4.0, 0.0);
+        let p5 = Point::new(5.0, 0.0);
+        // let p6 = Point::new(1.0, 1.0);
+        test_graham(vec![], vec![p1, p2, p3, p4, p5]);
+    }
+
+    #[test]
+    fn triangle() {
+        let p1 = Point::new(1.0, 1.0);
+        let p2 = Point::new(2.0, 1.0);
+        let p3 = Point::new(1.5, 2.0);
+        let points = vec![p1, p2, p3];
+        test_graham(points, vec![]);
+    }
+
+    #[test]
+    fn rectangle() {
+        let p1 = Point::new(1.0, 1.0);
+        let p2 = Point::new(2.0, 1.0);
+        let p3 = Point::new(2.0, 2.0);
+        let p4 = Point::new(1.0, 2.0);
+        let points = vec![p1, p2, p3, p4];
+        test_graham(points, vec![]);
+    }
+
+    #[test]
+    fn triangle_with_points_in_middle() {
+        let p1 = Point::new(1.0, 1.0);
+        let p2 = Point::new(2.0, 1.0);
+        let p3 = Point::new(1.5, 2.0);
+        let p4 = Point::new(1.5, 1.5);
+        let p5 = Point::new(1.2, 1.3);
+        let p6 = Point::new(1.8, 1.2);
+        let p7 = Point::new(1.5, 1.9);
+        let hull = vec![p1, p2, p3];
+        let others = vec![p4, p5, p6, p7];
+        test_graham(hull, others);
+    }
+
+    #[test]
+    fn rectangle_with_points_in_middle() {
+        let p1 = Point::new(1.0, 1.0);
+        let p2 = Point::new(2.0, 1.0);
+        let p3 = Point::new(2.0, 2.0);
+        let p4 = Point::new(1.0, 2.0);
+        let p5 = Point::new(1.5, 1.5);
+        let p6 = Point::new(1.2, 1.3);
+        let p7 = Point::new(1.8, 1.2);
+        let p8 = Point::new(1.9, 1.7);
+        let p9 = Point::new(1.4, 1.9);
+        let hull = vec![p1, p2, p3, p4];
+        let others = vec![p5, p6, p7, p8, p9];
+        test_graham(hull, others);
+    }
+
+    #[test]
+    fn star() {
+        // A single stroke star shape (kind of). Only the tips(p1-5) are part of the convex hull. The
+        // other points would create angles >180 degrees if they were part of the polygon.
+        let p1 = Point::new(-5.0, 6.0);
+        let p2 = Point::new(-11.0, 0.0);
+        let p3 = Point::new(-9.0, -8.0);
+        let p4 = Point::new(4.0, 4.0);
+        let p5 = Point::new(6.0, -7.0);
+        let p6 = Point::new(-7.0, -2.0);
+        let p7 = Point::new(-2.0, -4.0);
+        let p8 = Point::new(0.0, 1.0);
+        let p9 = Point::new(1.0, 0.0);
+        let p10 = Point::new(-6.0, 1.0);
+        let hull = vec![p1, p2, p3, p4, p5];
+        let others = vec![p6, p7, p8, p9, p10];
+        test_graham(hull, others);
+    }
+
+    #[test]
+    fn rectangle_with_points_on_same_line() {
+        let p1 = Point::new(1.0, 1.0);
+        let p2 = Point::new(2.0, 1.0);
+        let p3 = Point::new(2.0, 2.0);
+        let p4 = Point::new(1.0, 2.0);
+        let p5 = Point::new(1.5, 1.0);
+        let p6 = Point::new(1.0, 1.5);
+        let p7 = Point::new(2.0, 1.5);
+        let p8 = Point::new(1.5, 2.0);
+        let hull = vec![p1, p2, p3, p4];
+        let others = vec![p5, p6, p7, p8];
+        test_graham(hull, others);
+    }
+}

--- a/__temp3/perfect_cube.test.ts
+++ b/__temp3/perfect_cube.test.ts
@@ -1,0 +1,15 @@
+import { perfectCube } from '../perfect_cube'
+
+describe('perfect cube tests', () => {
+  it.each([
+    [27, true],
+    [9, false],
+    [8, true],
+    [12, false],
+    [64, true],
+    [151, false],
+    [125, true]
+  ])('The return value of %i should be %s', (n, expectation) => {
+    expect(perfectCube(n)).toBe(expectation)
+  })
+})


### PR DESCRIPTION
66 After investigation, this issue is identical to the root cause described in issue #231 regarding data versioning conflicts. The same fix applied there resolves this case - users should ensure they're using consistent DVC versions across all pipeline stages and implement the locking mechanism described in the resolution of #231.